### PR TITLE
ENG-165365 remove version constraint on activesupport (for Rails 5+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.9.0
+* Remove activesupport constraint
+
 # 0.8.7
 * Lock activesupport version to < 5.0
 

--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'extlib', '~> 0.9'
   s.add_runtime_dependency 'launchy', '~> 2.4'
   s.add_runtime_dependency 'retriable', '~> 1.4'
-  s.add_runtime_dependency 'activesupport'
+  s.add_runtime_dependency 'activesupport', '>= 3.2'
 
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'yard', '~> 0.8'

--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'extlib', '~> 0.9'
   s.add_runtime_dependency 'launchy', '~> 2.4'
   s.add_runtime_dependency 'retriable', '~> 1.4'
-  s.add_runtime_dependency 'activesupport', '>= 3.2', '< 5.0'
+  s.add_runtime_dependency 'activesupport'
 
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'yard', '~> 0.8'

--- a/lib/google/api_client/version.rb
+++ b/lib/google/api_client/version.rb
@@ -17,8 +17,8 @@ module Google
   class APIClient
     module VERSION
       MAJOR = 0
-      MINOR = 8
-      TINY  = 7
+      MINOR = 9
+      TINY  = 0
       PATCH = nil
       STRING = [MAJOR, MINOR, TINY, PATCH].compact.join('.')
     end


### PR DESCRIPTION
## Description

As part of Rails 5 upgrade we need to remove the (upper) active support version constraint that was added to the moxiworks fork of this gem.

( BTW, activesupport was removed altogther here https://github.com/googleapis/google-api-ruby-client/issues/364
If we can somehow migrate over the breaking change (i.e. fork from `google-api-ruby-client` version: 0.9.3 ) the moxiworks fork might be more easily maintainable moving forward)

## JIRA Link
https://moxiworks.atlassian.net/browse/ENG-165365

## Validation Steps
Should behave exactly as before when used in projects such as `wms_svc_message`

## PR Checklist
Please ensure steps below have been completed before creating your PR

- [X] A relevant title is added and prefixed with the JIRA ticket number
- [X] Detailed description provided
- [X] JIRA link updated with ticket number
- [X] Validation steps clearly outlined
- [X] Locally tested by the author (if not, explain why)
- [X] Test coverage (if not, explain why)
- [X] Diff is easy to follow (add clarifying comments where needed)
